### PR TITLE
filter-by attribute accept separate string by commas

### DIFF
--- a/poly-filter-behavior.html
+++ b/poly-filter-behavior.html
@@ -428,7 +428,7 @@
      */
     _concat: function(dest, values) {
       if (values) {
-        return dest.concat(values);
+        return dest.concat(typeof values === 'string' ? values.split(",") : values);
       }
       return dest;
     },


### PR DESCRIPTION
Hi, this component help me a lot, it is fast and easy, thanks! 
The filter-by accept array and string, but if you choose array, you have to declare the array in polymer properties, ok, this is not a problem, or you can also,  separate string by commas.
```html
<poly-filter array-to-filter="[[data]]" filter="[[searchTerm]]" filtered-array="{{dataFilter}}" filter-by="description,createdTime,updatedAt">
 </poly-filter>
```
